### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/finol-digital/FinolDigital.Cgs.Json/security/code-scanning/1](https://github.com/finol-digital/FinolDigital.Cgs.Json/security/code-scanning/1)

The fix is to add an explicit `permissions` declaration at the appropriate level in the workflow file. Since all jobs presently included in the workflow do not commit directly to the repository or alter other parts of the repository outside of what is already handled by PATs (personal access tokens), setting `permissions: contents: read` at the root of the workflow is the safest minimal starting point. If future jobs or current steps require additional permissions, such as to interact with issues or pull requests (e.g., the `create-pull-request` action), you can extend the root permissions or add more permissive blocks at the job level as needed, but for now, `contents: read` is typically sufficient for builds. Specifically, add the following block right after the workflow `name:` line and before `on:`.

No additional imports or methods are needed, just the addition to the workflow YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the .NET CI workflow to explicitly set the GITHUB_TOKEN to read-only for repository contents, aligning with least-privilege best practices.
  - No changes to workflow triggers, jobs, steps, or build/test behavior.

- Security
  - Reduced CI token scope to minimize risk during workflow execution.
  - No impact to application features, user experience, or release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->